### PR TITLE
Add test helpers made for iron-state-behaviors.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/PolymerElements/iron-test-helpers",
   "ignore": [],
   "dependencies": {
-    "polymer": "polymer/polymer#v0.8.0-rc.6"
+    "polymer": "polymer/polymer#v0.8.0-rc.7"
   }
 }

--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -17,10 +17,15 @@
     Polymer.Base.fire.call(target, 'mouseup');
   }
 
+  function tap(target) {
+    Polymer.Base.fire.call(target, 'tap');
+  }
+
   function downAndUp (target, callback) {
     down(target);
     Polymer.Base.async(function() {
       up(target);
+      tap(target);
 
       callback && callback();
     });


### PR DESCRIPTION
These changes were originally made in a copied version of the helpers found in `iron-state-behaviors`. This also bumps the bower.json to point to `polymer/polymer#v0.8.0-rc.7`.