### PR TITLE
fix 'down' mouse event

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -40,7 +40,9 @@
       bubbles: true,
       cancelable: true,
       clientX: xy.x,
-      clientY: xy.y
+      clientY: xy.y,
+      // Make this a primary input.
+      buttons: 1 // http://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
     };
     var e;
     var mousetype = type === 'tap' ? 'click' : 'mouse' + type;
@@ -48,8 +50,19 @@
       e = new MouseEvent(mousetype, props);
     } else {
       e = document.createEvent('MouseEvent');
-      e.initMouseEvent(mousetype, props.bubbles, props.cancelable, null, null, 0, 0,
-        props.clientX, props.clientY, false, false, false, false, 0, null);
+      e.initMouseEvent(
+        mousetype, props.bubbles, props.cancelable,
+        null, /* view */
+        null, /* detail */
+        0,    /* screenX */
+        0,    /* screenY */
+        props.clientX, props.clientY,
+        false, /*ctrlKey */
+        false, /*altKey */
+        false, /*shiftKey */
+        false, /*metaKey */
+        0,     /*button */
+        null   /*relatedTarget*/);
     }
     node.dispatchEvent(e);
   }


### PR DESCRIPTION
`IronControlState` expects the mouse event to be a "primary" input (https://github.com/PolymerElements/iron-behaviors/blob/master/iron-button-state.html#L128), and the existing `down` event didn't do this.

I've also documented the 17 billion parameters to `initMouseEvent` because 🔮

👉 @azakus @cdata 