### PR TITLE
make custom events cancelable

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -144,7 +144,8 @@
 
   function keyboardEventFor(type, keyCode) {
     var event = new CustomEvent(type, {
-      bubbles: true
+      bubbles: true,
+      cancelable: true
     });
 
     event.keyCode = keyCode;


### PR DESCRIPTION
Allows to cancel a CustomEvent (e.g. call preventDefault)
Needed by https://github.com/PolymerElements/iron-a11y-keys-behavior/pull/20