### PR TITLE
Use node instead of context for static fire.

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -107,14 +107,16 @@
   }
 
   function focus(target) {
-    Polymer.Base.fire.call(target, 'focus', {}, {
-      bubbles: false
+    Polymer.Base.fire('focus', {}, {
+      bubbles: false,
+      node: target
     });
   }
 
   function blur(target) {
-    Polymer.Base.fire.call(target, 'blur', {}, {
-      bubbles: false
+    Polymer.Base.fire('blur', {}, {
+      bubbles: false,
+      node: target
     });
   }
 


### PR DESCRIPTION
This is an alternative design to https://github.com/PolymerElements/iron-test-helpers/pull/30.

Fixes #29.
