### PR TITLE
add over function which simulate mouse over event and expose to MockInteractions

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -144,6 +144,11 @@
     up(target, xy2);
   }
 
+  function over(node, xy) {
+    xy = xy || middleOfNode(node);
+    makeEvent('over', xy, node);
+  }
+
   function keyboardEventFor(type, keyCode) {
     var event = new CustomEvent(type, {
       bubbles: true,
@@ -197,6 +202,7 @@
     keyDownOn: keyDownOn,
     keyUpOn: keyUpOn,
     middleOfNode: middleOfNode,
-    topLeftOfNode: topLeftOfNode
+    topLeftOfNode: topLeftOfNode,
+    over: over
   };
 })(this);


### PR DESCRIPTION
As I'm developing Custom Polymer elements, there're cases where I want to simulate unit test that fire on-mouse-over event (or hover event which effect css) which will allow unit test to assert whether css has been changed accordingly or not.