### PR TITLE
Initialize property 'detail' for mocked keyboard events

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -232,6 +232,7 @@
    */
   function keyboardEventFor(type, keyCode, modifiers) {
     var event = new CustomEvent(type, {
+      detail: 0,
       bubbles: true,
       cancelable: true
     });


### PR DESCRIPTION
This property is inquired by iron-a11y-keys-behavior for keys with
code > 123. For non-mocked keyboard event, this property holds the
value zero.

Fixes #46