### PR TITLE
Make `MockInteractions.tap` more true to life.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "^4.0.0"
+    "web-component-tester": "^4.0.0",
+    "paper-button": "^1.0.0"
   },
   "main": "iron-test-helpers.html"
 }

--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -53,6 +53,14 @@
     };
   }
 
+  /**
+   * Returns a list of Touch objects that correspond to an array of positions
+   * and a target node. The Touch instances will each have a unique Touch
+   * identifier.
+   *
+   * @param {Array} xyList A list of (x,y) coordinate objects.
+   * @param {HTMLElement} node A target element node.
+   */
   function makeTouches(xyList, node) {
     var id = 0;
 
@@ -68,6 +76,16 @@
     });
   }
 
+  /**
+   * Generates and dispatches a TouchEvent of a given type, at a specified
+   * position of a target node.
+   *
+   * @param {string} type The type of TouchEvent to generate.
+   * @param {{ x: number, y: number }} xy An (x,y) coordinate for the generated
+   * TouchEvent.
+   * @param {HTMLElement} node The target element node for the generated
+   * TouchEvent to be dispatched on.
+   */
   function makeSoloTouchEvent(type, xy, node) {
     var xy = xy || middleOfNode(node);
     var touches = makeTouches([xy], node);
@@ -94,7 +112,7 @@
    * Fires a mouse event on a specific node, at a given set of coordinates.
    * This event bubbles and is cancellable.
    *
-   * @param {String} type The type of mouse event (such as 'tap' or 'down').
+   * @param {string} type The type of mouse event (such as 'tap' or 'down').
    * @param {Object} xy The (x,y) coordinates the mouse event should be fired from.
    * @param {HTMLElement} node The node to fire the event on.
    */
@@ -137,7 +155,7 @@
    * @param {HTMLElement} node The node to fire the event on.
    * @param {Object} fromXY The (x,y) coordinates the dragging should start from.
    * @param {Object} toXY The (x,y) coordinates the dragging should end at.
-   * @param {Object} steps Optional. The numbers of steps in the move motion.
+   * @param {?Object} steps Optional. The numbers of steps in the move motion.
    *    If not specified, the default is 5.
    */
   function move(node, fromXY, toXY, steps) {
@@ -163,9 +181,9 @@
    * Simulates a mouse dragging action originating in the middle of a specific node.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {Number} dx The horizontal displacement.
-   * @param {Object} dy The vertical displacement
-   * @param {Object} steps Optional. The numbers of steps in the dragging motion.
+   * @param {?number} dx The horizontal displacement.
+   * @param {?number} dy The vertical displacement
+   * @param {?Object} steps Optional. The numbers of steps in the dragging motion.
    *    If not specified, the default is 5.
    */
   function track(target, dx, dy, steps) {
@@ -188,7 +206,10 @@
    * not specified, the middle of the node will be used instead.
    *
    * @param {HTMLElement} node The node to fire the event on.
-   * @param {Object} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+   * @param {?Object} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+   * @param {?{
+   *   emulateTouch: boolean
+   * }} options Optional. Configure the emulation fidelity of the mouse event.
    */
   function down(node, xy, options) {
     xy = xy || middleOfNode(node);
@@ -207,7 +228,10 @@
    * not specified, the middle of the node will be used instead.
    *
    * @param {HTMLElement} node The node to fire the event on.
-   * @param {Object} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+   * @param {?Object} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+   * @param {?{
+   *   emulateTouch: boolean
+   * }} options Optional. Configure the emulation fidelity of the mouse event.
    */
   function up(node, xy, options) {
     xy = xy || middleOfNode(node);
@@ -226,7 +250,10 @@
    *`callback` after the `tap` event is fired.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {Object} callback Optional. The function to be called after the action ends.
+   * @param {?Object} callback Optional. The function to be called after the action ends.
+   * @param {?{
+   *   emulateTouch: boolean
+   * }} options Optional. Configure the emulation fidelity of the mouse events.
    */
   function downAndUp(target, callback, options) {
     down(target, null, options);
@@ -242,7 +269,9 @@
    * set on the node, and will not fire on disabled nodes.
    *
    * @param {HTMLElement} node The node to fire the event on.
-   * @param {Object} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+   * @param {?{
+   *   emulateTouch: boolean
+   * }} options Optional. Configure the emulation fidelity of the mouse event.
    */
   function tap(node, options) {
     // Respect nodes that are disabled in the UI.
@@ -282,9 +311,9 @@
   /*
    * Returns a keyboard event. This event bubbles and is cancellable.
    *
-   * @param {String} type The type of keyboard event (such as 'keyup' or 'keydown').
-   * @param {Number} keyCode The keyCode for the event.
-   * @param {?String|[String]} modifiers The key modifiers for the event.
+   * @param {string} type The type of keyboard event (such as 'keyup' or 'keydown').
+   * @param {number} keyCode The keyCode for the event.
+   * @param {?string|[string]} modifiers The key modifiers for the event.
    * Accepted values are shift, ctrl, alt, meta.
    */
   function keyboardEventFor(type, keyCode, modifiers) {
@@ -312,9 +341,9 @@
    * Fires a keyboard event on a specific node. This event bubbles and is cancellable.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {String} type The type of keyboard event (such as 'keyup' or 'keydown').
-   * @param {Number} keyCode The keyCode for the event.
-   * @param {?String|[String]} modifiers The key modifiers for the event.
+   * @param {string} type The type of keyboard event (such as 'keyup' or 'keydown').
+   * @param {number} keyCode The keyCode for the event.
+   * @param {?string|[string]} modifiers The key modifiers for the event.
    * Accepted values are shift, ctrl, alt, meta.
    */
   function keyEventOn(target, type, keyCode, modifiers) {
@@ -325,8 +354,8 @@
    * Fires a 'keydown' event on a specific node. This event bubbles and is cancellable.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {Number} keyCode The keyCode for the event.
-   * @param {?String|[String]} modifiers The key modifiers for the event.
+   * @param {number} keyCode The keyCode for the event.
+   * @param {?string|[string]} modifiers The key modifiers for the event.
    * Accepted values are shift, ctrl, alt, meta.
    */
   function keyDownOn(target, keyCode, modifiers) {
@@ -337,8 +366,8 @@
    * Fires a 'keyup' event on a specific node. This event bubbles and is cancellable.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {Number} keyCode The keyCode for the event.
-   * @param {?String|[String]} modifiers The key modifiers for the event.
+   * @param {number} keyCode The keyCode for the event.
+   * @param {?string|[string]} modifiers The key modifiers for the event.
    * Accepted values are shift, ctrl, alt, meta.
    */
   function keyUpOn(target, keyCode, modifiers) {
@@ -350,8 +379,8 @@
    * by an asynchronous `keyup` event on a specific node.
    *
    * @param {HTMLElement} target The node to fire the event on.
-   * @param {Number} keyCode The keyCode for the event.
-   * @param {?String|[String]} modifiers The key modifiers for the event.
+   * @param {number} keyCode The keyCode for the event.
+   * @param {?string|[string]} modifiers The key modifiers for the event.
    * Accepted values are shift, ctrl, alt, meta.
    */
   function pressAndReleaseKeyOn(target, keyCode, modifiers) {

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>iron-test-helpers tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'mock-interactions.html'
+    ]);
+  </script>
+</body>
+</html>

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>mock-interactions basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../mock-interactions.js"></script>
+
+  <link rel="import" href="../../paper-button/paper-button.html">
+</head>
+<body>
+
+  <test-fixture id="TrivialButton">
+    <template>
+      <paper-button>Hello</paper-button>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('MockInteractions', function() {
+      var button;
+
+      setup(function() {
+        button = fixture('TrivialButton');
+      });
+
+      suite('simulating tap', function() {
+        test('only dispatches one tap event', function() {
+          var tapSpy = sinon.spy();
+          button.addEventListener('tap', tapSpy);
+          MockInteractions.tap(button, { emulateTouch: true });
+          button.removeEventListener('tap', tapSpy);
+          expect(tapSpy.callCount).to.be.eql(1);
+        });
+      });
+
+      suite('simulating down and up', function() {
+        test('only dispatches one tap event', function(done) {
+          var tapSpy = sinon.spy();
+          button.addEventListener('tap', tapSpy);
+          MockInteractions.downAndUp(button, function() {
+            button.removeEventListener('tap', tapSpy);
+            expect(tapSpy.callCount).to.be.eql(1);
+            done();
+          }, { emulateTouch: true });
+        });
+      })
+    });
+
+  </script>
+</body>
+</html>

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -36,13 +36,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         button = fixture('TrivialButton');
       });
 
+      teardown(function(done) {
+        // TODO(cdata): Remove when polymer/polymer#3540 is resolved
+        window.setTimeout(function() {
+          done();
+        }, 2500);
+      });
+
       suite('simulating tap', function() {
         test('only dispatches one tap event', function() {
           var tapSpy = sinon.spy();
           button.addEventListener('tap', tapSpy);
-          MockInteractions.tap(button, { emulateTouch: true });
+          MockInteractions.tap(button);
           button.removeEventListener('tap', tapSpy);
           expect(tapSpy.callCount).to.be.eql(1);
+        });
+
+        suite('with touch emulation', function() {
+          test('only dispatches one tap event', function() {
+            var tapSpy = sinon.spy();
+            button.addEventListener('tap', tapSpy);
+            MockInteractions.tap(button, { emulateTouch: true });
+            button.removeEventListener('tap', tapSpy);
+            expect(tapSpy.callCount).to.be.eql(1);
+          });
         });
       });
 
@@ -54,9 +71,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             button.removeEventListener('tap', tapSpy);
             expect(tapSpy.callCount).to.be.eql(1);
             done();
-          }, { emulateTouch: true });
+          });
         });
-      })
+
+        suite('with touch emulation', function() {
+          test('only dispatches one tap event', function(done) {
+            var tapSpy = sinon.spy();
+            button.addEventListener('tap', tapSpy);
+            MockInteractions.downAndUp(button, function() {
+              button.removeEventListener('tap', tapSpy);
+              expect(tapSpy.callCount).to.be.eql(1);
+              done();
+            }, { emulateTouch: true });
+          });
+        });
+      });
     });
 
   </script>


### PR DESCRIPTION
Since real world `tap` scenarios will often involve companion touch
events, `MockInteractions.tap`, `MockInteractions.down` and
`MockInteractions.up` will all cause corresponding `TouchEvent`s to be
fired in tandem with the typical `MouseEvent`s.