### PR TITLE
Added Modifiers To Mouse Events

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -108,7 +108,7 @@
    * @param {{ x: number, y: number }} xy The (x,y) coordinates the mouse event should be fired from.
    * @param {!HTMLElement} node The node to fire the event on.
    */
-  function makeMouseEvent(type, xy, node) {
+  function makeMouseEvent(type, xy, node, options) {
     var props = {
       bubbles: true,
       cancelable: true,
@@ -117,6 +117,13 @@
       // Make this a primary input.
       buttons: 1 // http://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
     };
+    if (options) {
+      props.ctrlKey = options.ctrlKey || false;
+      props.altKey = options.altKey || false;
+      props.shiftKey = options.shiftKey || false;
+      props.metaKey = options.metaKey || false;
+    }
+
     var e;
     if (HAS_NEW_MOUSE) {
       e = new MouseEvent(type, props);
@@ -129,10 +136,10 @@
         0,    /* screenX */
         0,    /* screenY */
         props.clientX, props.clientY,
-        false, /*ctrlKey */
-        false, /*altKey */
-        false, /*shiftKey */
-        false, /*metaKey */
+        options.ctrlKey || false, /*ctrlKey */
+        options.altKey || false, /*altKey */
+        options.shiftKey || false, /*shiftKey */
+        options.metaKey || false, /*metaKey */
         0,     /*button */
         null   /*relatedTarget*/);
     }
@@ -199,9 +206,9 @@
    * @param {!HTMLElement} node The node to fire the event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
    */
-  function down(node, xy) {
+  function down(node, xy, options) {
     xy = xy || middleOfNode(node);
-    makeMouseEvent('mousedown', xy, node);
+    makeMouseEvent('mousedown', xy, node, options);
   }
 
   /**
@@ -212,9 +219,9 @@
    * @param {!HTMLElement} node The node to fire the event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
    */
-  function up(node, xy) {
+  function up(node, xy, options) {
     xy = xy || middleOfNode(node);
-    makeMouseEvent('mouseup', xy, node);
+    makeMouseEvent('mouseup', xy, node, options);
   }
 
   /**
@@ -223,9 +230,9 @@
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should
    * be fired from.
    */
-  function click(node, xy) {
+  function click(node, xy, options) {
     xy = xy || middleOfNode(node);
-    makeMouseEvent('click', xy, node);
+    makeMouseEvent('click', xy, node, options);
   }
 
   /**
@@ -268,10 +275,10 @@
       touchend(target);
     }
 
-    down(target);
+    down(target, options);
     Polymer.Base.async(function() {
-      up(target);
-      click(target);
+      up(target, options);
+      click(target, options);
       callback && callback();
     });
   }
@@ -297,9 +304,9 @@
       touchend(node, xy);
     }
 
-    down(node, xy);
-    up(node, xy);
-    click(node, xy);
+    down(node, xy, options);
+    up(node, xy, options);
+    click(node, xy, options);
   }
 
   /**

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -52,6 +52,47 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(tapSpy.callCount).to.be.eql(1);
         });
 
+        test('dispatches tap event with shift pressed', function(done) {
+          var tapSpy = function(e) {
+            button.removeEventListener('click', tapSpy);
+            expect(e.shiftKey).to.be.true;
+            done();
+          };
+          button.addEventListener('click', tapSpy);
+          MockInteractions.tap(button, {shiftKey: true});
+        });
+
+        test('dispatches tap event with ctrl pressed', function(done) {
+          var tapSpy = function(e) {
+            button.removeEventListener('click', tapSpy);
+            expect(e.ctrlKey).to.be.true;
+            done();
+          };
+          button.addEventListener('click', tapSpy);
+          MockInteractions.tap(button, {ctrlKey: true});
+        });
+
+        test('dispatches tap event with alt pressed', function(done) {
+          var tapSpy = function(e) {
+            button.removeEventListener('click', tapSpy);
+            expect(e.altKey).to.be.true;
+            done();
+          };
+          button.addEventListener('click', tapSpy);
+          MockInteractions.tap(button, {altKey: true});
+        });
+
+        test('dispatches tap event with the meta-key pressed', function(done) {
+          var tapSpy = function(e) {
+            button.removeEventListener('click', tapSpy);
+            expect(e.metaKey).to.be.true;
+            done();
+          };
+          button.addEventListener('click', tapSpy);
+          MockInteractions.tap(button, {metaKey: true});
+        });
+
+
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
             var tapSpy = sinon.spy();


### PR DESCRIPTION
Added the mockability of key modifiers to tap, click, up, and down
mouse events. This allows the mocking of more complicated key/mouse
combinations.