### PR TITLE
Fix MockInteractions.track to provide correct step values

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -151,8 +151,8 @@
    */
   function move(node, fromXY, toXY, steps) {
     steps = steps || 5;
-    var dx = Math.round((fromXY.x - toXY.x) / steps);
-    var dy = Math.round((fromXY.y - toXY.y) / steps);
+    var dx = Math.round((toXY.x - fromXY.x) / steps);
+    var dy = Math.round((toXY.y - fromXY.y) / steps);
     var xy = {
       x: fromXY.x,
       y: fromXY.y

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -36,11 +36,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         button = fixture('TrivialButton');
       });
 
-      teardown(function(done) {
-        // TODO(cdata): Remove when polymer/polymer#3540 is resolved
-        window.setTimeout(function() {
-          done();
-        }, 2500);
+      teardown(function() {
+        Polymer.Gestures.resetMouseCanceller();
       });
 
       suite('simulating tap', function() {
@@ -84,6 +81,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             }, { emulateTouch: true });
           });
+        });
+      });
+
+      suite('simulating track', function() {
+        test('dispatches events with correct steps', function() {
+          var spy = sinon.spy();
+          button.handleTrack = spy;
+          button.listen(button, 'track', 'handleTrack');
+          MockInteractions.track(button, 50, 50, 5);
+
+          var steps = [10, 20, 30, 40, 50, 50];
+          for (var i = 0, l = steps.length; i < l; i++) {
+            expect(spy.getCall(i).args[0].detail.dx).to.be.eql(steps[i]);
+            expect(spy.getCall(i).args[0].detail.dy).to.be.eql(steps[i]);
+          }
         });
       });
     });


### PR DESCRIPTION
Fixes #59, the delta computations in the `move` function were the wrong way around.

Also get rid of the `setTimeout` call in the test suite since polymer/polymer#3540 is resolved
