### PR TITLE
Making iron-test-helpers work with JSCompiler

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -22,7 +22,7 @@
   /**
    * Returns the (x,y) coordinates representing the middle of a node.
    *
-   * @param {!HTMLElement} node An element.
+   * @param {!Element} node An element.
    */
   function middleOfNode(node) {
     var bcr = node.getBoundingClientRect();
@@ -35,7 +35,7 @@
   /**
    * Returns the (x,y) coordinates representing the top left corner of a node.
    *
-   * @param {!HTMLElement} node An element.
+   * @param {!Element} node An element.
    */
   function topLeftOfNode(node) {
     var bcr = node.getBoundingClientRect();
@@ -51,7 +51,7 @@
    * identifier.
    *
    * @param {!Array<{ x: number, y: number }>} xyList A list of (x,y) coordinate objects.
-   * @param {!HTMLElement} node A target element node.
+   * @param {!Element} node A target element node.
    */
   function makeTouches(xyList, node) {
     var id = 0;
@@ -75,7 +75,7 @@
    * @param {string} type The type of TouchEvent to generate.
    * @param {{ x: number, y: number }} xy An (x,y) coordinate for the generated
    * TouchEvent.
-   * @param {!HTMLElement} node The target element node for the generated
+   * @param {!Element} node The target element node for the generated
    * TouchEvent to be dispatched on.
    */
   function makeSoloTouchEvent(type, xy, node) {
@@ -106,7 +106,7 @@
    *
    * @param {string} type The type of mouse event (such as 'tap' or 'down').
    * @param {{ x: number, y: number }} xy The (x,y) coordinates the mouse event should be fired from.
-   * @param {!HTMLElement} node The node to fire the event on.
+   * @param {!Element} node The node to fire the event on.
    */
   function makeMouseEvent(type, xy, node) {
     var props = {
@@ -143,10 +143,10 @@
    * Simulates a mouse move action by firing a `move` mouse event on a
    * specific node, between a set of coordinates.
    *
-   * @param {!HTMLElement} node The node to fire the event on.
+   * @param {!Element} node The node to fire the event on.
    * @param {Object} fromXY The (x,y) coordinates the dragging should start from.
    * @param {Object} toXY The (x,y) coordinates the dragging should end at.
-   * @param {?number} steps Optional. The numbers of steps in the move motion.
+   * @param {?number=} steps Optional. The numbers of steps in the move motion.
    *    If not specified, the default is 5.
    */
   function move(node, fromXY, toXY, steps) {
@@ -171,10 +171,10 @@
   /**
    * Simulates a mouse dragging action originating in the middle of a specific node.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    * @param {?number} dx The horizontal displacement.
    * @param {?number} dy The vertical displacement
-   * @param {?number} steps Optional. The numbers of steps in the dragging motion.
+   * @param {?number=} steps Optional. The numbers of steps in the dragging motion.
    *    If not specified, the default is 5.
    */
   function track(target, dx, dy, steps) {
@@ -196,7 +196,7 @@
    * This event bubbles and is cancellable. If the (x,y) coordinates are
    * not specified, the middle of the node will be used instead.
    *
-   * @param {!HTMLElement} node The node to fire the event on.
+   * @param {!Element} node The node to fire the event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
    */
   function down(node, xy) {
@@ -209,7 +209,7 @@
    * This event bubbles and is cancellable. If the (x,y) coordinates are
    * not specified, the middle of the node will be used instead.
    *
-   * @param {!HTMLElement} node The node to fire the event on.
+   * @param {!Element} node The node to fire the event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
    */
   function up(node, xy) {
@@ -219,7 +219,7 @@
 
   /**
    * Generate a click event on a given node, optionally at a given coordinate.
-   * @param {!HTMLElement} node The node to fire the click event on.
+   * @param {!Element} node The node to fire the click event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should
    * be fired from.
    */
@@ -230,7 +230,7 @@
 
   /**
    * Generate a touchstart event on a given node, optionally at a given coordinate.
-   * @param {!HTMLElement} node The node to fire the click event on.
+   * @param {!Element} node The node to fire the click event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the touch event should
    * be fired from.
    */
@@ -242,7 +242,7 @@
 
   /**
    * Generate a touchend event on a given node, optionally at a given coordinate.
-   * @param {!HTMLElement} node The node to fire the click event on.
+   * @param {!Element} node The node to fire the click event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the touch event should
    * be fired from.
    */
@@ -256,11 +256,11 @@
    * by an asynchronous `up` and `tap` events on a specific node. Calls the
    *`callback` after the `tap` event is fired.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
-   * @param {?Function} callback Optional. The function to be called after the action ends.
+   * @param {!Element} target The node to fire the event on.
+   * @param {?Function=} callback Optional. The function to be called after the action ends.
    * @param {?{
    *   emulateTouch: boolean
-   * }} options Optional. Configure the emulation fidelity of the mouse events.
+   * }=} options Optional. Configure the emulation fidelity of the mouse events.
    */
   function downAndUp(target, callback, options) {
     if (options && options.emulateTouch) {
@@ -280,10 +280,10 @@
    * Fires a 'tap' mouse event on a specific node. This respects the pointer-events
    * set on the node, and will not fire on disabled nodes.
    *
-   * @param {!HTMLElement} node The node to fire the event on.
+   * @param {!Element} node The node to fire the event on.
    * @param {?{
    *   emulateTouch: boolean
-   * }} options Optional. Configure the emulation fidelity of the mouse event.
+   * }=} options Optional. Configure the emulation fidelity of the mouse event.
    */
   function tap(node, options) {
     // Respect nodes that are disabled in the UI.
@@ -305,7 +305,7 @@
   /**
    * Focuses a node by firing a `focus` event. This event does not bubble.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    */
   function focus(target) {
     Polymer.Base.fire('focus', {}, {
@@ -317,7 +317,7 @@
   /**
    * Blurs a node by firing a `blur` event. This event does not bubble.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    */
   function blur(target) {
     Polymer.Base.fire('blur', {}, {
@@ -362,7 +362,7 @@
   /**
    * Fires a keyboard event on a specific node. This event bubbles and is cancellable.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    * @param {string} type The type of keyboard event (such as 'keyup' or 'keydown').
    * @param {number} keyCode The keyCode for the event.
    * @param {(string|Array<string>)=} modifiers The key modifiers for the event.
@@ -376,7 +376,7 @@
   /**
    * Fires a 'keydown' event on a specific node. This event bubbles and is cancellable.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    * @param {number} keyCode The keyCode for the event.
    * @param {(string|Array<string>)=} modifiers The key modifiers for the event.
    *     Accepted values are shift, ctrl, alt, meta.
@@ -389,7 +389,7 @@
   /**
    * Fires a 'keyup' event on a specific node. This event bubbles and is cancellable.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    * @param {number} keyCode The keyCode for the event.
    * @param {(string|Array<string>)=} modifiers The key modifiers for the event.
    *     Accepted values are shift, ctrl, alt, meta.
@@ -403,7 +403,7 @@
    * Simulates a complete key press by firing a `keydown` keyboard event, followed
    * by an asynchronous `keyup` event on a specific node.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    * @param {number} keyCode The keyCode for the event.
    * @param {(string|Array<string>)=} modifiers The key modifiers for the event.
    *     Accepted values are shift, ctrl, alt, meta.
@@ -420,7 +420,7 @@
    * Simulates a complete 'enter' key press by firing a `keydown` keyboard event,
    * followed by an asynchronous `keyup` event on a specific node.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    */
   function pressEnter(target) {
     pressAndReleaseKeyOn(target, 13);
@@ -430,7 +430,7 @@
    * Simulates a complete 'space' key press by firing a `keydown` keyboard event,
    * followed by an asynchronous `keyup` event on a specific node.
    *
-   * @param {!HTMLElement} target The node to fire the event on.
+   * @param {!Element} target The node to fire the event on.
    */
   function pressSpace(target) {
     pressAndReleaseKeyOn(target, 32);

--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -8,8 +8,14 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-(function(global) {
+// We declare it as a namespace to be compatible with JSCompiler.
+/** @const */ var MockInteractions = {};
+
+(function(scope, global) {
   'use strict';
+
+  // In case the var above was not global, or if it was renamed.
+  global.MockInteractions = scope;
 
   var HAS_NEW_MOUSE = (function() {
     var has = false;
@@ -436,22 +442,20 @@
     pressAndReleaseKeyOn(target, 32);
   }
 
-  global.MockInteractions = {
-    focus: focus,
-    blur: blur,
-    down: down,
-    up: up,
-    downAndUp: downAndUp,
-    tap: tap,
-    track: track,
-    pressAndReleaseKeyOn: pressAndReleaseKeyOn,
-    pressEnter: pressEnter,
-    pressSpace: pressSpace,
-    keyDownOn: keyDownOn,
-    keyUpOn: keyUpOn,
-    keyboardEventFor: keyboardEventFor,
-    keyEventOn: keyEventOn,
-    middleOfNode: middleOfNode,
-    topLeftOfNode: topLeftOfNode
-  };
-})(this);
+  scope.focus = focus;
+  scope.blur = blur;
+  scope.down = down;
+  scope.up = up;
+  scope.downAndUp = downAndUp;
+  scope.tap = tap;
+  scope.track = track;
+  scope.pressAndReleaseKeyOn = pressAndReleaseKeyOn;
+  scope.pressEnter = pressEnter;
+  scope.pressSpace = pressSpace;
+  scope.keyDownOn = keyDownOn;
+  scope.keyUpOn = keyUpOn;
+  scope.keyboardEventFor = keyboardEventFor;
+  scope.keyEventOn = keyEventOn;
+  scope.middleOfNode = middleOfNode;
+  scope.topLeftOfNode = topLeftOfNode;
+})(MockInteractions, this);

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -8,8 +8,14 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-(function(global) {
+// We declare it as a namespace to be compatible with JSCompiler.
+/** @const */ var TestHelpers = {};
+
+(function(scope, global) {
   'use strict';
+
+  // In case the var above was not global, or if it was renamed.
+  global.TestHelpers = scope;
 
   /**
    * Forces distribution of light children, and lifecycle callbacks on the
@@ -87,10 +93,8 @@
     };
   };
 
-  global.TestHelpers = {
-    flushAsynchronousOperations: global.flushAsynchronousOperations,
-    forceXIfStamp: global.forceXIfStamp,
-    fireEvent: global.fireEvent,
-    skipUnless: global.skipUnless
-  };
-})(this);
+  scope.flushAsynchronousOperations = global.flushAsynchronousOperations;
+  scope.forceXIfStamp = global.forceXIfStamp;
+  scope.fireEvent = global.fireEvent;
+  scope.skipUnless = global.skipUnless;
+})(TestHelpers, this);

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -7,9 +7,9 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
+
 (function(global) {
   'use strict';
-
 
   /**
    * Forces distribution of light children, and lifecycle callbacks on the
@@ -26,7 +26,7 @@
   /**
    * Stamps and renders a `dom-if` template.
    *
-   * @param {HTMLElement} node The node containing the template,
+   * @param {!Element} node The node containing the template,
    */
   global.forceXIfStamp = function(node) {
     var templates = Polymer.dom(node.root).querySelectorAll('template[is=dom-if]');
@@ -41,8 +41,8 @@
    * Fires a custom event on a specific node. This event bubbles and is cancellable.
    *
    * @param {string} type The type of event.
-   * @param {Object} props Any custom properties the event contains.
-   * @param {HTMLElement} node The node to fire the event on.
+   * @param {?Object} props Any custom properties the event contains.
+   * @param {!Element} node The node to fire the event on.
    */
   global.fireEvent = function(type, props, node) {
     var event = new CustomEvent(type, {
@@ -67,7 +67,6 @@
    * @param {Function} condition The name of a Boolean function determining if the test should be run.
    * @param {Function} test The test to be run.
    */
-
   global.skipUnless = function(condition, test) {
     var isAsyncTest = !!test.length;
 

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -43,6 +43,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 2500);
       });
 
+      suite('class registration', function() {
+        test('registers to window', function() {
+          expect(MockInteractions).to.exist;
+          expect(MockInteractions.tap).to.exist;
+        });
+
+        test('registers to this', function() {
+          // Download the script with a synchronous xhr.
+          var xhr = new XMLHttpRequest();
+          xhr.open('get', '../mock-interactions.js', false);
+          xhr.send();
+          expect(xhr.responseText).to.exist;
+          // Execute it in a specific context.
+          var context = {};
+          Function(xhr.responseText).call(context);
+          expect(context.MockInteractions).to.exist;
+          expect(context.MockInteractions.tap).to.exist;
+        });
+      });
+
       suite('simulating tap', function() {
         test('only dispatches one tap event', function() {
           var tapSpy = sinon.spy();

--- a/test/test-helpers.html
+++ b/test/test-helpers.html
@@ -11,16 +11,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>iron-test-helpers tests</title>
+  <title>test-helpers basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
+  <script src="../test-helpers.js"></script>
 </head>
 <body>
+
   <script>
-    WCT.loadSuites([
-      'mock-interactions.html',
-      'test-helpers.html'
-    ]);
+    suite('TestHelpers', function() {
+    });
+
   </script>
 </body>
 </html>

--- a/test/test-helpers.html
+++ b/test/test-helpers.html
@@ -22,6 +22,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     suite('TestHelpers', function() {
+      suite('class registration', function() {
+        test('registers to window', function() {
+          expect(TestHelpers).to.exist;
+          expect(TestHelpers.forceXIfStamp).to.exist;
+          expect(forceXIfStamp).to.exist;
+        });
+
+        test('registers to this', function() {
+          // Download the script with a synchronous xhr.
+          var xhr = new XMLHttpRequest();
+          xhr.open('get', '../test-helpers.js', false);
+          xhr.send();
+          expect(xhr.responseText).to.exist;
+          // Execute it in a specific context.
+          var context = {};
+          Function(xhr.responseText).call(context);
+          expect(context.TestHelpers).to.exist;
+          expect(context.TestHelpers.forceXIfStamp).to.exist;
+          expect(context.forceXIfStamp).to.exist;
+        });
+      });
     });
 
   </script>


### PR DESCRIPTION
This fixes #68.

I fixed some type annotations that are described in the issue. I changed class registration so that it registers into an object instead of this, and JSCompiler will recognize that object as a namespace. And then it will correctly infer the methods and their signatures in that namespace. I added tests for the class registration itself, but there should probably be a test that invokes the real JSCompiler to be sure it works. I haven't yet thought about how to implement that though.