### PR TITLE
Populate event.which for keyboard events

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -350,6 +350,7 @@
 
     event.keyCode = keyCode;
     event.code = keyCode;
+    event.which = keyCode;
 
     modifiers = modifiers || [];
     if (typeof modifiers === 'string') {


### PR DESCRIPTION
Major browsers (CHrome, FF, Safari, IE and Edge) have event.which for keyboard events whic is equal to event.keyCode. For better compatibility this should be done in mock.