### PR TITLE
Fix touch support detecting

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -24,6 +24,14 @@
     } catch (_) {}
     return has;
   })();
+  
+  var HAS_NEW_TOUCH = (function() {
+    var has = false;
+    try {
+      has = Boolean(new TouchEvent('x'));
+    } catch (_) {}
+    return has;
+  })();
 
   /**
    * Returns the (x,y) coordinates representing the middle of a node.
@@ -70,7 +78,7 @@
         clientY: xy.y
       };
 
-      return window.Touch ? new window.Touch(touchInit) : touchInit;
+      return HAS_NEW_TOUCH ? new window.Touch(touchInit) : touchInit;
     });
   }
 
@@ -94,7 +102,7 @@
     };
     var event;
 
-    if (window.TouchEvent) {
+    if (HAS_NEW_TOUCH) {
       touchEventInit.bubbles = true;
       touchEventInit.cancelable = true;
       event = new TouchEvent(type, touchEventInit);


### PR DESCRIPTION
Fix touch support detecting for mobile devices like

- OS X 10.11 iphone 9.2
- OS X 10.11 ipad 9.2
- Linux android 5.1

This PR is fixing `TouchEventConstructor is not a constructor (evaluating 'new TouchEvent(type, touchEventInit)')` excaption, see more details: https://travis-ci.org/vaadin/vaadin-split-layout/builds/190211039