### PR TITLE
Fix detecting HAS_NEW_MOUSE for IE

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -17,14 +17,17 @@
   // In case the var above was not global, or if it was renamed.
   global.MockInteractions = scope;
 
-  var HAS_NEW_MOUSE = (function() {
-    var has = false;
-    try {
-      has = Boolean(new MouseEvent('x'));
-    } catch (_) {}
-    return has;
-  })();
-  
+  var HAS_NEW_MOUSE;
+  window.addEventListener('WebComponentsReady', function() {
+    HAS_NEW_MOUSE = (function() {
+      var has = false;
+      try {
+        has = Boolean(new MouseEvent('x'));
+      } catch (_) {}
+      return has;
+    })();
+  });
+
   var HAS_NEW_TOUCH = (function() {
     var has = false;
     try {


### PR DESCRIPTION
For IE `MouseEvent` constructor is [polyfilled](https://github.com/webcomponents/webcomponents-platform/blob/203270306f3beeceae0229f60dbf66dba18f3c18/webcomponents-platform.js#L72) and available after `WebComponentsReady`

Before `WebComponentsReady` `MouseEvent` is undefined and `HAS_NEW_MOUSE` isn't detected  properly