### PR TITLE
Added wrapper function for mouseover, mouseenter, and mouseleave 

### DIFF
--- a/mock-interactions.js
+++ b/mock-interactions.js
@@ -240,7 +240,46 @@
     makeMouseEvent('mouseup', xy, node);
   }
 
-  /**
+    /**
+     * Fires a `mouseenter` mouse event on a specific node, at a given set of coordinates.
+     * This event bubbles and is cancellable. If the (x,y) coordinates are
+     * not specified, the middle of the node will be used instead.
+     *
+     * @param {!Element} node The node to fire the event on.
+     * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+     */
+    function mouseenter(node, xy) {
+        xy = xy || middleOfNode(node);
+        makeMouseEvent('mouseenter', xy, node);
+    }
+
+    /**
+     * Fires a `mouseenter` mouse event on a specific node, at a given set of coordinates.
+     * This event bubbles and is cancellable. If the (x,y) coordinates are
+     * not specified, the middle of the node will be used instead.
+     *
+     * @param {!Element} node The node to fire the event on.
+     * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+     */
+    function mouseover(node, xy) {
+        xy = xy || middleOfNode(node);
+        makeMouseEvent('mouseover', xy, node);
+    }
+
+    /**
+     * Fires a `mouseleave` mouse event on a specific node, at a given set of coordinates.
+     * This event bubbles and is cancellable. If the (x,y) coordinates are
+     * not specified, the middle of the node will be used instead.
+     *
+     * @param {!Element} node The node to fire the event on.
+     * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should be fired from.
+     */
+    function mouseleave(node, xy) {
+        xy = xy || middleOfNode(node);
+        makeMouseEvent('mouseleave', xy, node);
+    }
+
+    /**
    * Generate a click event on a given node, optionally at a given coordinate.
    * @param {!Element} node The node to fire the click event on.
    * @param {{ x: number, y: number }=} xy Optional. The (x,y) coordinates the mouse event should
@@ -466,6 +505,9 @@
   scope.down = down;
   scope.up = up;
   scope.downAndUp = downAndUp;
+  scope.mouseenter = mouseenter;
+  scope.mouseleave = mouseleave;
+  scope.mouseover = mouseover;
   scope.tap = tap;
   scope.move = move;
   scope.touchstart = touchstart;

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -175,6 +175,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       });
+
+      suite('simulating mouse events', function() {
+            test('mouseenter event gets dispatched', function(done) {
+                button.addEventListener('mouseenter', function(event) {
+                    expect(event).to.exist;
+                    expect(event.type).to.be.eql('mouseenter');
+                    done();
+                });
+                MockInteractions.mouseenter(button);
+            });
+            test('mouseleave event gets dispatched', function(done) {
+                button.addEventListener('mouseleave', function(event) {
+                    expect(event).to.exist;
+                    expect(event.type).to.be.eql('mouseleave');
+                    done();
+                });
+                MockInteractions.mouseleave(button);
+            });
+            test('mouseover event gets dispatched', function(done) {
+                button.addEventListener('mouseover', function(event) {
+                    expect(event).to.exist;
+                    expect(event.type).to.be.eql('mouseover');
+                    done();
+                });
+                MockInteractions.mouseover(button);
+            });
+        });
     });
 
   </script>


### PR DESCRIPTION
Fixes #90, fixes #65 by creating three new functions mouseenter(node, xy), mouseleave(node, xy), and mouseover(node, xy) that wrap the makeMouseEvent(eventName, xy, node) function.