### PR TITLE
skip tests failing on master and remove unmodulizable test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components*
 bower-*.json
+node_modules

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -66,19 +66,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(MockInteractions).to.exist;
           expect(MockInteractions.tap).to.exist;
         });
-
-        test('registers to this', function() {
-          // Download the script with a synchronous xhr.
-          var xhr = new XMLHttpRequest();
-          xhr.open('get', '../mock-interactions.js', false);
-          xhr.send();
-          expect(xhr.responseText).to.exist;
-          // Execute it in a specific context.
-          var context = {};
-          Function(xhr.responseText).call(context);
-          expect(context.MockInteractions).to.exist;
-          expect(context.MockInteractions.tap).to.exist;
-        });
       });
 
       suite('simulating tap', function() {
@@ -115,6 +102,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
+            this.skip();
             button = button.$.inner;
             var tapSpy = sinon.spy();
             Polymer.Gestures.add(button, 'tap', tapSpy);
@@ -164,6 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function(done) {
+            this.skip();
             button = button.$.inner;
             var tapSpy = sinon.spy();
             Polymer.Gestures.add(button, 'tap', tapSpy);

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -102,7 +102,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
-            this.skip();
             button = button.$.inner;
             var tapSpy = sinon.spy();
             Polymer.Gestures.add(button, 'tap', tapSpy);
@@ -152,7 +151,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function(done) {
-            this.skip();
             button = button.$.inner;
             var tapSpy = sinon.spy();
             Polymer.Gestures.add(button, 'tap', tapSpy);

--- a/test/test-helpers.html
+++ b/test/test-helpers.html
@@ -28,20 +28,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(TestHelpers.forceXIfStamp).to.exist;
           expect(forceXIfStamp).to.exist;
         });
-
-        test('registers to this', function() {
-          // Download the script with a synchronous xhr.
-          var xhr = new XMLHttpRequest();
-          xhr.open('get', '../test-helpers.js', false);
-          xhr.send();
-          expect(xhr.responseText).to.exist;
-          // Execute it in a specific context.
-          var context = {};
-          Function(xhr.responseText).call(context);
-          expect(context.TestHelpers).to.exist;
-          expect(context.TestHelpers.forceXIfStamp).to.exist;
-          expect(context.forceXIfStamp).to.exist;
-        });
       });
     });
 


### PR DESCRIPTION
one of these tests is not modulizable, and speaking to peter, it was put in in a very very specific use case for a very unlikely case.

The test skips were simply because they failed on master