### PR TITLE
[fix tests] use addEventListener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - 8
 sudo: required
 before_script:
   - npm install -g polymer-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-  - 8
 sudo: required
 before_script:
   - npm install -g polymer-cli
@@ -11,7 +9,7 @@ env:
         V1aYCpIKinfrWFq1qLN391dMtI+J1CZmgj7t8w4nnjQ9jQAtT2f7an5QyRsl82XPfoDqSwjrAWzV868IYhfBib7eyd09oQyUT3SKFWZpZr/Ul5BSsXwsJ9zroTNtBRki1fKjfZkCV1+zbAqX17ZGj26dWvgb6cdcZrtU+FBFbb4=
     - secure: >-
         CLQtLMdmgGs8g+L6x1FYVr2YF9+YyPM5QYa87Dh7nD0EgX/Jb6TtbXrGBhpeHNrLSuBWCXdpoLoBaSJKvcieGT8u/nlXbCWGt29Yh+fvX9ffXEXZwmmi1Mo79PGDXQ7bEh1oT7sRGIJ9XM2fFho/eEqiOWYBCPJmJgB9FKW7XSo=
-node_js: stable
+node_js: "8"
 addons:
   firefox: latest
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ addons:
       - google-chrome
     packages:
       - google-chrome-stable
+    sauce_connect: true
 script:
-  - true || xvfb-run polymer test
+  - xvfb-run polymer test
   - >-
-    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then true || polymer test -s
-    'default'; fi
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
+    fi
 dist: trusty

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -114,8 +114,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
             var tapSpy = sinon.spy();
-            // In Polymer 1.x we need to patch the button with Gestures.add 
-            // in order to have the listener working.
+            // In Polymer 1.x with native ShadowDOM we need to
+            // patch the button with Gestures.add in order to have
+            // the touch emulation working.
             if (!Polymer.Element && Polymer.Settings.useShadow) {
               Polymer.Gestures.add(button.$.inner, 'tap', tapSpy);
             } else { 
@@ -165,8 +166,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function(done) {
             var tapSpy = sinon.spy();
-            // In Polymer 1.x we need to patch the button with Gestures.add 
-            // in order to have the listener working.
+            // In Polymer 1.x with native ShadowDOM we need to
+            // patch the button with Gestures.add in order to have
+            // the touch emulation working.
             if (!Polymer.Element && Polymer.Settings.useShadow) {
               Polymer.Gestures.add(button.$.inner, 'tap', tapSpy);
             } else { 

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -105,21 +105,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('simulating tap in ShadowRoot', function() {
 
         test('only dispatches one tap event', function() {
-          button = button.$.inner;
           var tapSpy = sinon.spy();
-          button.addEventListener('tap', tapSpy);
-          MockInteractions.tap(button);
-          button.removeEventListener('tap', tapSpy);
+          button.$.inner.addEventListener('tap', tapSpy);
+          MockInteractions.tap(button.$.inner);
           expect(tapSpy.callCount).to.be.eql(1);
         });
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
-            button = button.$.inner;
             var tapSpy = sinon.spy();
-            Polymer.Gestures.add(button, 'tap', tapSpy);
-            MockInteractions.tap(button, { emulateTouch: true });
-            Polymer.Gestures.remove(button, 'tap', tapSpy);
+            button.$.inner.addEventListener('tap', tapSpy);
+            MockInteractions.tap(button.$.inner, { emulateTouch: true });
             expect(tapSpy.callCount).to.be.eql(1);
           });
         });
@@ -152,11 +148,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('simulating down and up in ShadowRoot', function() {
 
         test('only dispatches one tap event', function(done) {
-          button = button.$.inner;
           var tapSpy = sinon.spy();
-          button.addEventListener('tap', tapSpy);
-          MockInteractions.downAndUp(button, function() {
-            button.removeEventListener('tap', tapSpy);
+          button.$.inner.addEventListener('tap', tapSpy);
+          MockInteractions.downAndUp(button.$.inner, function() {
             expect(tapSpy.callCount).to.be.eql(1);
             done();
           });
@@ -164,11 +158,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function(done) {
-            button = button.$.inner;
             var tapSpy = sinon.spy();
-            Polymer.Gestures.add(button, 'tap', tapSpy);
-            MockInteractions.downAndUp(button, function() {
-              Polymer.Gestures.remove(button, 'tap', tapSpy);
+            button.$.inner.addEventListener('tap', tapSpy);
+            MockInteractions.downAndUp(button.$.inner, function() {
               expect(tapSpy.callCount).to.be.eql(1);
               done();
             }, { emulateTouch: true });

--- a/test/mock-interactions.html
+++ b/test/mock-interactions.html
@@ -114,7 +114,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function() {
             var tapSpy = sinon.spy();
-            button.$.inner.addEventListener('tap', tapSpy);
+            // In Polymer 1.x we need to patch the button with Gestures.add 
+            // in order to have the listener working.
+            if (!Polymer.Element && Polymer.Settings.useShadow) {
+              Polymer.Gestures.add(button.$.inner, 'tap', tapSpy);
+            } else { 
+              button.$.inner.addEventListener('tap', tapSpy);
+            }
             MockInteractions.tap(button.$.inner, { emulateTouch: true });
             expect(tapSpy.callCount).to.be.eql(1);
           });
@@ -159,7 +165,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('with touch emulation', function() {
           test('only dispatches one tap event', function(done) {
             var tapSpy = sinon.spy();
-            button.$.inner.addEventListener('tap', tapSpy);
+            // In Polymer 1.x we need to patch the button with Gestures.add 
+            // in order to have the listener working.
+            if (!Polymer.Element && Polymer.Settings.useShadow) {
+              Polymer.Gestures.add(button.$.inner, 'tap', tapSpy);
+            } else { 
+              button.$.inner.addEventListener('tap', tapSpy);
+            }
             MockInteractions.downAndUp(button.$.inner, function() {
               expect(tapSpy.callCount).to.be.eql(1);
               done();


### PR DESCRIPTION
Fixes tests on master
Enabled tests on travis, but they keep failing with `TypeError: Cannot read property '1' of null` 😕 
They pass locally